### PR TITLE
Make the prober mod public and handle all events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ panic = 'abort'     # Abort on panic
 
 [features]
 default = []
+serde = ["dep:serde"]
 
 [dependencies]
 lightning = { version = "0.0.123", features = ["std"] }
@@ -69,6 +70,7 @@ tokio = { version = "1.37", default-features = false, features = [ "rt-multi-thr
 esplora-client = { version = "0.6", default-features = false }
 libc = "0.2"
 uniffi = { version = "0.26.0", features = ["build"], optional = true }
+serde = { version = "1.0.210", default-features = false, features = ["derive"], optional =  true }
 
 [target.'cfg(vss)'.dependencies]
 vss-client = "0.3"

--- a/src/event.rs
+++ b/src/event.rs
@@ -156,6 +156,7 @@ pub enum Event {
 		payment_id: PaymentId,
 		/// The hash of the payment.
 		payment_hash: PaymentHash,
+		// The path that the probe took.
 		// path: Path,
 	},
 	/// Indicates that a probe payment we sent failed at an intermediary node on the path.
@@ -227,7 +228,6 @@ impl_writeable_tlv_based_enum!(Event,
 		(1, payment_hash, required),
 		// (2, path.hops, required_vec),
 		(3, short_channel_id, option),
-		// (4, path.blinded_tail, option),
 	};
 );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ mod logger;
 mod message_handler;
 pub mod payment;
 mod peer_store;
-mod prober;
+pub mod prober;
 mod sweep;
 mod tx_broadcaster;
 mod types;


### PR DESCRIPTION
Forgot to make the prober mod public so that the structs could be used by the Prober.

This also handles all events in ldk node directly so that the the Probe events all get handled correctly while that is happening here. Otherwise, there is a race between event handling in the Prober and event handling here which can cause Probes to hang. This is temporary, next step is to figure out how to serialize those Probe events so that we can do this in the Prober.