### PR TITLE
[LN-1005] Add methods to configure and manipulate the Scorer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,24 +28,25 @@ panic = 'abort'     # Abort on panic
 default = []
 
 [dependencies]
-lightning = { version = "0.0.125", features = ["std"] }
-lightning-invoice = { version = "0.32.0" }
-lightning-net-tokio = { version = "0.0.125" }
-lightning-persister = { version = "0.0.125" }
-lightning-background-processor = { version = "0.0.125", features = ["futures"] }
-lightning-rapid-gossip-sync = { version = "0.0.125" }
-lightning-block-sync = { version = "0.0.125", features = ["rpc-client", "tokio"] }
-lightning-transaction-sync = { version = "0.0.125", features = ["esplora-async-https", "time"] }
-lightning-liquidity = { version = "0.1.0-alpha.6", features = ["std"] }
+# lightning = { version = "0.0.125", features = ["std"] }
+# lightning-invoice = { version = "0.32.0" }
+# lightning-net-tokio = { version = "0.0.125" }
+# lightning-persister = { version = "0.0.125" }
+# lightning-background-processor = { version = "0.0.125", features = ["futures"] }
+# lightning-rapid-gossip-sync = { version = "0.0.125" }
+# lightning-block-sync = { version = "0.0.125", features = ["rpc-client", "tokio"] }
+# lightning-transaction-sync = { version = "0.0.125", features = ["esplora-async-https", "time"] }
+# lightning-liquidity = { version = "0.1.0-alpha.6", features = ["std"] }
 
-#lightning = { git = "https://github.com/lightningdevkit/rust-lightning", branch="main", features = ["std"] }
-#lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", branch="main" }
-#lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", branch="main" }
-#lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", branch="main" }
-#lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", branch="main", features = ["futures"] }
-#lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", branch="main" }
-#lightning-transaction-sync = { git = "https://github.com/lightningdevkit/rust-lightning", branch="main", features = ["esplora-async"] }
-#lightning-liquidity = { git = "https://github.com/lightningdevkit/lightning-liquidity", branch="main", features = ["std"] }
+lightning = { git = "https://github.com/cequals/rust-lightning", branch="amackillop/0.0.125-patched", features = ["std"] }
+lightning-invoice = { git = "https://github.com/cequals/rust-lightning", branch="amackillop/0.0.125-patched" }
+lightning-net-tokio = { git = "https://github.com/cequals/rust-lightning", branch="amackillop/0.0.125-patched" }
+lightning-persister = { git = "https://github.com/cequals/rust-lightning", branch="amackillop/0.0.125-patched" }
+lightning-background-processor = { git = "https://github.com/cequals/rust-lightning", branch="amackillop/0.0.125-patched", features = ["futures"] }
+lightning-rapid-gossip-sync = { git = "https://github.com/cequals/rust-lightning", branch="amackillop/0.0.125-patched" }
+lightning-block-sync = { git = "https://github.com/cequals/rust-lightning", branch="amackillop/0.0.125-patched", features = ["rpc-client", "tokio"] }
+lightning-transaction-sync = { git = "https://github.com/cequals/rust-lightning", branch="amackillop/0.0.125-patched", features = ["esplora-async-https", "time"] }
+lightning-liquidity = { git = "https://github.com/cequals/lightning-liquidity", branch="amackillop/v0.1.0-alpha.6-patched", features = ["std"] }
 
 #lightning = { path = "../rust-lightning/lightning", features = ["std"] }
 #lightning-invoice = { path = "../rust-lightning/lightning-invoice" }
@@ -83,8 +84,8 @@ prost = { version = "0.11.6", default-features = false}
 winapi = { version = "0.3", features = ["winbase"] }
 
 [dev-dependencies]
-lightning = { version = "0.0.125", features = ["std", "_test_utils"] }
-#lightning = { git = "https://github.com/lightningdevkit/rust-lightning", branch="main", features = ["std", "_test_utils"] }
+# lightning = { version = "0.0.125", features = ["std", "_test_utils"] }
+lightning = { git = "https://github.com/cequals/rust-lightning", branch="amackillop/0.0.125-patched", features = ["std", "_test_utils"] }
 electrum-client = { version = "0.21.0", default-features = true }
 bitcoincore-rpc = { version = "0.19.0", default-features = false }
 proptest = "1.0.0"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -333,7 +333,9 @@ impl NodeBuilder {
 	}
 
 	/// Sets the parameters for the scoring algorithm.
-	pub fn set_scoring_params(&mut self, scoring_params: ProbabilisticScoringParameters) -> &mut Self {
+	pub fn set_scoring_params(
+		&mut self, scoring_params: ProbabilisticScoringParameters,
+	) -> &mut Self {
 		self.config.scoring_parameters = scoring_params;
 		self
 	}
@@ -1236,12 +1238,10 @@ fn setup_logger(config: &Config) -> Result<Arc<LdkNodeLogger>, BuildError> {
 		LoggingConfig::Filesystem { ref log_dir, log_level } => {
 			let filesystem_log_writer = FilesystemLogWriter::new(log_dir.clone())
 				.map_err(|_| BuildError::LoggerSetupFailed)?;
-			Ok(Arc::new(
-				LdkNodeLogger::new(
-					log_level,
-					Box::new(move |record| filesystem_log_writer.write(&default_format(record))),
-				),
-			))
+			Ok(Arc::new(LdkNodeLogger::new(
+				log_level,
+				Box::new(move |record| filesystem_log_writer.write(&default_format(record))),
+			)))
 		},
 	}
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@
 
 use crate::logger::LdkNodeLogger;
 use crate::payment::SendingParameters;
+use crate::prober::ProbabilisticScoringParameters;
 
 use lightning::ln::msgs::SocketAddress;
 use lightning::routing::gossip::NodeAlias;
@@ -159,6 +160,10 @@ pub struct Config {
 	/// **Note:** If unset, default parameters will be used, and you will be able to override the
 	/// parameters on a per-payment basis in the corresponding method calls.
 	pub sending_parameters: Option<SendingParameters>,
+
+	/// The parameters used to configure the [`lightning::routing::scoring::ProbabilisticScorer`] 
+	/// used by the node.
+	pub scoring_parameters: ProbabilisticScoringParameters,
 }
 
 impl Default for Config {
@@ -173,6 +178,7 @@ impl Default for Config {
 			anchor_channels_config: Some(AnchorChannelsConfig::default()),
 			sending_parameters: None,
 			node_alias: None,
+			scoring_parameters: ProbabilisticScoringParameters::default(),
 		}
 	}
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -161,7 +161,7 @@ pub struct Config {
 	/// parameters on a per-payment basis in the corresponding method calls.
 	pub sending_parameters: Option<SendingParameters>,
 
-	/// The parameters used to configure the [`lightning::routing::scoring::ProbabilisticScorer`] 
+	/// The parameters used to configure the [`lightning::routing::scoring::ProbabilisticScorer`]
 	/// used by the node.
 	pub scoring_parameters: ProbabilisticScoringParameters,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -935,6 +935,7 @@ impl Node {
 			Arc::clone(&self.channel_manager),
 			Arc::clone(&self.router),
 			Arc::clone(&self.scorer),
+			Arc::clone(&self.network_graph),
 			Arc::clone(&self.logger),
 			self.node_id(),
 		)

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -26,8 +26,8 @@ pub struct LdkNodeLogger {
 
 impl LdkNodeLogger {
 	/// Creates a new `LdkNodeLogger`.
-	pub fn new(level: Level, writer: Box<dyn Fn(&Record) + Send + Sync>) -> Result<Self, ()> {
-		Ok(Self { level, writer })
+	pub fn new(level: Level, writer: Box<dyn Fn(&Record) + Send + Sync>) -> Self {
+		Self { level, writer }
 	}
 }
 

--- a/src/prober.rs
+++ b/src/prober.rs
@@ -63,7 +63,10 @@ impl Prober {
 		let inflight_htlcs = self.channel_manager.compute_inflight_htlcs();
 		self.router
 			.find_route(&self.node_id, &route_params, Some(&first_hops[..]), inflight_htlcs)
-			.map_err(|_| Error::RouteNotFound)
+			.map_err(|e| {
+				log_error!(self.logger, "Failed to find route: {e:?}");
+				Error::RouteNotFound
+			})
 	}
 
 	/// Send a probe along the given path returning the payment hash and id of the fake payment.


### PR DESCRIPTION
This PR adds scoring parameters to the node configuration. This allows for setting custom scoring parameters which we will use to run experiments. This also adds the methods to import/export/reset the scorer and update its decay parameters. Updating fee parameters requires a restart of the node to update the router