### PR TITLE
Disable payment claiming

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -588,10 +588,15 @@ where
 				onion_fields,
 				counterparty_skimmed_fee_msat,
 			} => {
+				let payment_id = PaymentId(payment_hash.0);
+				log_info!(
+					self.logger,
+					"Refused inbound payment with ID {}: claiming is disabled.",
+					payment_id
+				);
 				self.channel_manager.fail_htlc_backwards(&payment_hash);
 				return Ok(());
 				// NOTE: Claiming of payments has been disabled.
-				let payment_id = PaymentId(payment_hash.0);
 				if let Some(info) = self.payment_store.get(&payment_id) {
 					if info.direction == PaymentDirection::Outbound {
 						log_info!(

--- a/src/event.rs
+++ b/src/event.rs
@@ -588,6 +588,9 @@ where
 				onion_fields,
 				counterparty_skimmed_fee_msat,
 			} => {
+				self.channel_manager.fail_htlc_backwards(&payment_hash);
+				return Ok(());
+				// NOTE: Claiming of payments has been disabled.
 				let payment_id = PaymentId(payment_hash.0);
 				if let Some(info) = self.payment_store.get(&payment_id) {
 					if info.direction == PaymentDirection::Outbound {


### PR DESCRIPTION
This stops the sending of any payments to the Prober. May also need to restrict channel opens to just c= as well as in theory a random node could also open with push_msat