### PR TITLE
[LN-1032] Add method to fully sync RGS on demand

### DIFF
--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -58,11 +58,12 @@ impl GossipSource {
 		}
 	}
 
-	pub async fn update_rgs_snapshot(&self) -> Result<u32, Error> {
+	pub async fn update_rgs_snapshot(&self, do_full_sync: bool) -> Result<u32, Error> {
 		match self {
 			Self::P2PNetwork { gossip_sync: _ } => Ok(0),
 			Self::RapidGossipSync { gossip_sync, server_url, latest_sync_timestamp, logger } => {
-				let query_timestamp = latest_sync_timestamp.load(Ordering::Acquire);
+				let query_timestamp =
+					if do_full_sync { 0 } else { latest_sync_timestamp.load(Ordering::Acquire) };
 				let query_url = format!("{}/{}", server_url, query_timestamp);
 
 				let response = tokio::time::timeout(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,7 @@ impl Node {
 						_ = interval.tick() => {
 							let gossip_sync_logger = Arc::clone(&gossip_sync_logger);
 							let now = Instant::now();
-							match gossip_source.update_rgs_snapshot().await {
+							match gossip_source.update_rgs_snapshot(false).await {
 								Ok(updated_timestamp) => {
 									log_trace!(
 										gossip_sync_logger,
@@ -1255,6 +1255,14 @@ impl Node {
 				},
 			)
 		})
+	}
+
+	/// Manually sync the RGS snapshot.
+	///
+	/// If `do_full_sync` is true, the RGS snapshot will be updated from scratch. Otherwise, the
+	/// snapshot will be updated from the last known sync point.
+	pub async fn sync_rgs(&self, do_full_sync: bool) -> Result<u32, Error> {
+		self.gossip_source.update_rgs_snapshot(do_full_sync).await
 	}
 
 	/// Close a previously opened channel.


### PR DESCRIPTION
Adds a simple method to fully sync RGS data ie use timestamp `0`