### PR TITLE
Use MonitorUpdatingPersister for ChainMonitor

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -19,7 +19,7 @@ use lightning::routing::gossip;
 use lightning::routing::router::DefaultRouter;
 use lightning::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringFeeParameters};
 use lightning::sign::InMemorySigner;
-use lightning::util::persist::{KVStore, KVStoreSync};
+use lightning::util::persist::{KVStore, KVStoreSync, MonitorUpdatingPersister};
 use lightning::util::ser::{Readable, Writeable, Writer};
 use lightning::util::sweep::OutputSweeper;
 use lightning_block_sync::gossip::{GossipVerifier, UtxoSource};
@@ -55,7 +55,14 @@ pub(crate) type ChainMonitor = chainmonitor::ChainMonitor<
 	Arc<Broadcaster>,
 	Arc<OnchainFeeEstimator>,
 	Arc<Logger>,
-	Arc<DynStore>,
+	Arc<MonitorUpdatingPersister<
+		Arc<DynStore>,
+		Arc<Logger>,
+		Arc<KeysManager>,
+		Arc<KeysManager>,
+		Arc<Broadcaster>,
+		Arc<OnchainFeeEstimator>,
+	>>,
 	Arc<KeysManager>,
 >;
 


### PR DESCRIPTION
Replace direct KVStore usage with MonitorUpdatingPersister to enable incremental channel monitor updates instead of rewriting the entire monitor on each update. This improves I/O efficiency by writing only differential updates (typically hundreds of bytes) rather than rewriting the full monitor (potentially tens of megabytes) for each state change. The existing behaviour tends to make channel updates very slow after a few thousand updates.

The persister is configured with a maximum of 100 pending updates before consolidating to a full monitor write. This balances I/O bandwidth savings against storage complexity.

Note: MonitorUpdatingPersister format is not backward-compatible with the standard persister due to the sentinel byte sequence prepended to monitors.